### PR TITLE
Adding a more informative message if no supported environments are found...

### DIFF
--- a/cluster.sh
+++ b/cluster.sh
@@ -25,6 +25,7 @@ function usage {
 
         Supported environment tags:
         $(grep --no-messages 'SUPPORTED_ENVS.*=' ./lib/${PROVIDER}_command.rb)
+        $([ $? -ne 0 ] && echo "No supported environment tags found for ${PROVIDER}")
 EOT
 }
 # @formatter:on


### PR DESCRIPTION
@jwhonce This displays the output a little more nicely for the user.