### PR TITLE
base_os role fixes

### DIFF
--- a/roles/base_os/tasks/main.yaml
+++ b/roles/base_os/tasks/main.yaml
@@ -11,21 +11,18 @@
     src: vimrc
     dest: /root/.vimrc
 
-- name: Ensure vimrc is installed for user root
-  copy:
-    src: vimrc
-    dest: /root/.vimrc
-
 - name: Install firewalld
   yum:
     pkg: firewalld
     state: installed
 
-- name: enable firewalld service
-  command: /usr/bin/systemctl enable firewalld.service
-
-- name: start firewalld service
-  command: /usr/bin/systemctl start firewalld.service
+- name: start and enable firewalld service
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
+  register: result
 
 - name: need to pause here, otherwise the firewalld service starting can sometimes cause ssh to fail
   pause: seconds=10
+  when: result | changed


### PR DESCRIPTION
- remove duplicate .vimrc task
- consolidate firewalld commands to a single service task
- only pause for firewalld service startup if the state of the firewalld
  service task changes

Most of these changes are sourced from https://github.com/openshift/openshift-online-ansible/pull/46, the only unique with this PR is to only pause if the firewalld service task state is changed