### PR TITLE
Additional changes for SSL enabling the api and console ports

### DIFF
--- a/roles/base_os/tasks/main.yaml
+++ b/roles/base_os/tasks/main.yaml
@@ -11,21 +11,26 @@
     src: vimrc
     dest: /root/.vimrc
 
-- name: Ensure vimrc is installed for user root
-  copy:
-    src: vimrc
-    dest: /root/.vimrc
+- name: Add KUBECONFIG to .bash_profile for user root
+  lineinfile:
+    dest: /root/.bash_profile
+    regexp: "KUBECONFIG="
+    line: "export KUBECONFIG={{ openshift_master_credentials_dir }}.kubeconfig"
+    state: present
+    insertafter: EOF
 
 - name: Install firewalld
   yum:
     pkg: firewalld
     state: installed
 
-- name: enable firewalld service
-  command: /usr/bin/systemctl enable firewalld.service
-
-- name: start firewalld service
-  command: /usr/bin/systemctl start firewalld.service
+- name: start and enable firewalld service
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
+  register: result
 
 - name: need to pause here, otherwise the firewalld service starting can sometimes cause ssh to fail
   pause: seconds=10
+  when: result | changed

--- a/roles/base_os/tasks/main.yaml
+++ b/roles/base_os/tasks/main.yaml
@@ -15,7 +15,7 @@
   lineinfile:
     dest: /root/.bash_profile
     regexp: "KUBECONFIG="
-    line: "export KUBECONFIG={{ openshift_master_credentials_dir }}.kubeconfig"
+    line: "export KUBECONFIG=/var/lib/openshift/openshift.local.certificates/admin/.kubeconfig"
     state: present
     insertafter: EOF
 

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -13,21 +13,24 @@
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
   with_items:
-    - { regex: '^OPTIONS=', line: 'OPTIONS=\"--public-master={{ oo_public_ip }} --nodes={{ oo_node_ips | join(",") }}  --loglevel=5\"' }
+    - { regex: '^OPTIONS=', line: "OPTIONS=\"--public-master={{ oo_public_ip }} --nodes={{ oo_node_ips | join(",") }}  --loglevel=5\"" }
   notify:
     - restart openshift-master
 
-- name: Open firewalld port for etcd embedded in OpenShift
-  firewalld: port=4001/tcp permanent=false state=enabled
+# Open etcd embedded, etcd embedded peer, openshift api, and
+# openshift client ports
+- name: Open firewalld ports for openshift-master
+  firewalld: port={{ item[0] }} permanent={{ item[1] }} state=enabled
+  with_nested:
+  - [ 4001/tcp, 7001/tcp, 8443/tcp, 8444/tcp ]
+  - [ true, false ]
 
-- name: Save firewalld port for etcd embedded in
-  firewalld: port=4001/tcp permanent=true state=enabled
-
-- name: Open firewalld port for OpenShift
-  firewalld: port=8443/tcp permanent=false state=enabled
-
-- name: Save firewalld port for OpenShift
-  firewalld: port=8443/tcp permanent=true state=enabled
+# Disable previously exposed ports that are no longer needed
+- name: Close firewalld ports for openshift-master that are no longer needed
+  firewalld: port={{ item[0] }} permanent={{ item[1] }} state=enabled
+  with_nested:
+  - [ 8080/tcp ]
+  - [ true, false ]
 
 - name: Enable OpenShift
   service: name=openshift-master enabled=yes state=started

--- a/roles/openshift_master/tasks/main.yml
+++ b/roles/openshift_master/tasks/main.yml
@@ -24,10 +24,10 @@
   firewalld: port=4001/tcp permanent=true state=enabled
 
 - name: Open firewalld port for OpenShift
-  firewalld: port=8080/tcp permanent=false state=enabled
+  firewalld: port=8443/tcp permanent=false state=enabled
 
 - name: Save firewalld port for OpenShift
-  firewalld: port=8080/tcp permanent=true state=enabled
+  firewalld: port=8443/tcp permanent=true state=enabled
 
 - name: Enable OpenShift
   service: name=openshift-master enabled=yes state=started

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -39,6 +39,6 @@
 
   # Always bounce service to pick up new credentials
 - name: Enable OpenShift
-  service: name=openshift-node enabled=yes state=restarted
+  service: name=openshift-node enabled=yes state=started
 
 - local_action: file name={{ mktemp.stdout }} state=absent

--- a/roles/openshift_node/tasks/main.yml
+++ b/roles/openshift_node/tasks/main.yml
@@ -27,7 +27,7 @@
     regexp: "{{ item.regex }}"
     line: "{{ item.line }}"
   with_items:
-    - { regex: '^OPTIONS=', line: 'OPTIONS=\"--master=http://{{ oo_master_ips[0] }}:8080  --loglevel=5\"' }
+    - { regex: '^OPTIONS=', line: 'OPTIONS=\"--master=https://{{ oo_master_ips[0] }}:8443  --loglevel=5\"' }
   notify:
     - restart openshift-node
 
@@ -37,7 +37,8 @@
 - name: Save firewalld port for OpenShift
   firewalld: port=10250/tcp permanent=true state=enabled
 
+  # Always bounce service to pick up new credentials
 - name: Enable OpenShift
-  service: name=openshift-node enabled=yes state=started
+  service: name=openshift-node enabled=yes state=restarted
 
 - local_action: file name={{ mktemp.stdout }} state=absent


### PR DESCRIPTION
Builds upon https://github.com/openshift/openshift-online-ansible/pull/69 by adding KUBECONFIG to .bash_profile for the root user.

- roles/base_os: Without this, the root user would need to manually configure this variable before attempting to run any osc commands
- roles/base_os: Cleanup the firewall service definition and only pause when the service state changes.
- roles/openshift_master: use Akram's suggestion of simplifying the firewall config
- roles/openshift_master: explicitly disable previously exposed ports that are no longer exposed (8080/tcp I'm looking at you).